### PR TITLE
fix awk command to parse jool output

### DIFF
--- a/jool_session.sh
+++ b/jool_session.sh
@@ -8,9 +8,9 @@
 # $YOUR_KEY_OF_ICMP_ON_ZABBIX=jool.icmp.session
 
 # substituting TCP/UDP/ICMP session to variable
-TCP=`jool -c --session --tcp | awk '{print $2}'`
-UDP=`jool -c --session --udp | awk '{print $2}'`
-ICMP=`jool -c --session --icmp | awk '{print $2}'`
+TCP=`jool -c --session --tcp | awk '{print $NF}'`
+UDP=`jool -c --session --udp | awk '{print $NF}'`
+ICMP=`jool -c --session --icmp | awk '{print $NF}'`
 
 # run zabbix_sender
 /usr/bin/zabbix_sender -z $YOUR_ZABBIX_IPADDR -p 10051 -s $YOUR_JOOL_HOSTNAME_ON_ZABBIX -k $YOUR_KEY_OF_TCP_ON_ZABBIX -o ${TCP} 


### PR DESCRIPTION
既存のコードではjoolコマンドが、2カラム目に値を出力することを想定しているようですが
現在(2017/09)のバージョンでは1カラムのみになったようです。

最後のカラムの値を取るという動作の方が互換性を保ちつつ値も取れるため、
awkにて2カラム決め打ちからNFに変更しました。